### PR TITLE
DT Tamanho dos ícones na tela de estatísticas

### DIFF
--- a/src/components/Statistics/DonutChart/DonutChart.tsx
+++ b/src/components/Statistics/DonutChart/DonutChart.tsx
@@ -19,7 +19,7 @@ interface DonutChartProps {
 
 export const DonutChart: FC<DonutChartProps> = ({ data }) => {
   return (
-    <div className="flex items-center gap-6">
+    <div className="flex items-center flex-wrap justify-center">
       <MantineDonutChart
         data={data.map(({ name, value, color }) => ({
           name,
@@ -45,16 +45,31 @@ export const DonutChart: FC<DonutChartProps> = ({ data }) => {
               className="inline-block rounded-full"
               style={{ background: color, width: 24, height: 24 }}
             />
-            <Image
-              src={icon}
-              alt={name}
-              width={16}
-              height={16}
+            <div
               style={{
-                filter:
-                  'brightness(0) saturate(100%) invert(13%) sepia(0%) saturate(7482%) hue-rotate(146deg) brightness(98%) contrast(87%)',
+                width: 24,
+                height: 24,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                overflow: 'hidden',
               }}
-            />
+            >
+              <Image
+                src={icon}
+                alt={name}
+                width={16}
+                height={16}
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  objectFit: 'contain',
+                  filter:
+                    'brightness(0) saturate(100%) invert(13%) sepia(0%) saturate(7482%) hue-rotate(146deg) brightness(98%) contrast(87%)',
+                  display: 'block',
+                }}
+              />
+            </div>
             <Text
               as="span"
               size="sub"


### PR DESCRIPTION
## Link da Tarefa

[Link da tarefa no board do projeto](https://github.com/users/vicente-hofmeister/projects/2/views/1?pane=issue&itemId=112833538&issue=vicente-hofmeister%7CCreativeFlow-Frontend%7C12). 

## Descrição

Neste MR, foi corrigido a diferença de tamanho entre os ícones de interesse dependendo do interesse selecionado pelo usuário.

## Screenshots da tela/componente

### Antes

![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-11 at 18 42 58](https://github.com/user-attachments/assets/cafb25e6-5170-4ddb-b00e-3980af007909)

### Depois

![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-11 at 18 43 20](https://github.com/user-attachments/assets/2a3f8bf2-f62e-42b4-89d4-57c239977bf0)

## Checklist do AGES III

- [X] Não deixou string literais no código.
- [X] Utilizou as variáveis padronizadas do design system (cor, títulos/fontes).
- [X] Seguiu padrões de nomenclatura de arquivos
- [X] Seguiu padrões da árvore de diretórios
- [X] Não deixou código comentado.